### PR TITLE
geom_alt props

### DIFF
--- a/data/421/168/997/421168997.geojson
+++ b/data/421/168/997/421168997.geojson
@@ -584,6 +584,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459008789,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c982a71624b6c930bd8837bb00552772",
     "wof:hierarchy":[
         {
@@ -595,7 +598,7 @@
         }
     ],
     "wof:id":421168997,
-    "wof:lastmodified":1566615442,
+    "wof:lastmodified":1582347042,
     "wof:name":"Porto-Novo",
     "wof:parent_id":421169223,
     "wof:placetype":"locality",

--- a/data/421/169/001/421169001.geojson
+++ b/data/421/169/001/421169001.geojson
@@ -430,6 +430,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459008790,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6fb2b8d6d17857a93c8873b6fb7f04b7",
     "wof:hierarchy":[
         {
@@ -441,7 +444,7 @@
         }
     ],
     "wof:id":421169001,
-    "wof:lastmodified":1566615442,
+    "wof:lastmodified":1582347042,
     "wof:name":"Cotonou",
     "wof:parent_id":421202663,
     "wof:placetype":"locality",

--- a/data/421/169/223/421169223.geojson
+++ b/data/421/169/223/421169223.geojson
@@ -482,6 +482,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459008800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c982a71624b6c930bd8837bb00552772",
     "wof:hierarchy":[
         {
@@ -492,7 +495,7 @@
         }
     ],
     "wof:id":421169223,
-    "wof:lastmodified":1566615442,
+    "wof:lastmodified":1582347042,
     "wof:name":"Porto-Novo",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/421/169/231/421169231.geojson
+++ b/data/421/169/231/421169231.geojson
@@ -231,6 +231,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459008800,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8edc50c3255e84c965f0f6daa2697b17",
     "wof:hierarchy":[
         {
@@ -241,7 +244,7 @@
         }
     ],
     "wof:id":421169231,
-    "wof:lastmodified":1566615442,
+    "wof:lastmodified":1582347043,
     "wof:name":"Natitingou",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/421/172/113/421172113.geojson
+++ b/data/421/172/113/421172113.geojson
@@ -131,6 +131,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459008920,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1493c602363a13c0270bea2976221d21",
     "wof:hierarchy":[
         {
@@ -141,7 +144,7 @@
         }
     ],
     "wof:id":421172113,
-    "wof:lastmodified":1566615444,
+    "wof:lastmodified":1582347043,
     "wof:name":"Tanguieta",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/421/174/729/421174729.geojson
+++ b/data/421/174/729/421174729.geojson
@@ -201,6 +201,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459009042,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cd98c9e6a872be3bc2e3c7c2fe497f13",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":421174729,
-    "wof:lastmodified":1566615443,
+    "wof:lastmodified":1582347043,
     "wof:name":"Ouidah",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/421/177/249/421177249.geojson
+++ b/data/421/177/249/421177249.geojson
@@ -155,6 +155,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459009137,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8fc1126b0ac42c24b1f4c5f06b8ffeb9",
     "wof:hierarchy":[
         {
@@ -165,7 +168,7 @@
         }
     ],
     "wof:id":421177249,
-    "wof:lastmodified":1566615446,
+    "wof:lastmodified":1582347043,
     "wof:name":"Grand-Popo",
     "wof:parent_id":85668823,
     "wof:placetype":"county",

--- a/data/421/186/271/421186271.geojson
+++ b/data/421/186/271/421186271.geojson
@@ -150,6 +150,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459009475,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e830ca0d10954d5526382479a1cf428",
     "wof:hierarchy":[
         {
@@ -160,7 +163,7 @@
         }
     ],
     "wof:id":421186271,
-    "wof:lastmodified":1566615444,
+    "wof:lastmodified":1582347043,
     "wof:name":"Abomey-Calavi",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/421/195/933/421195933.geojson
+++ b/data/421/195/933/421195933.geojson
@@ -122,6 +122,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459009864,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c0f28c6426c1dd197401e6a704fe9093",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":421195933,
-    "wof:lastmodified":1566615442,
+    "wof:lastmodified":1582347042,
     "wof:name":"Kpomasse",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/421/202/551/421202551.geojson
+++ b/data/421/202/551/421202551.geojson
@@ -153,6 +153,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459010122,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1caa02447c505bc4272c39d685c55a7",
     "wof:hierarchy":[
         {
@@ -163,7 +166,7 @@
         }
     ],
     "wof:id":421202551,
-    "wof:lastmodified":1566615443,
+    "wof:lastmodified":1582347043,
     "wof:name":"Allada",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/421/202/663/421202663.geojson
+++ b/data/421/202/663/421202663.geojson
@@ -350,6 +350,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1459010125,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6fb2b8d6d17857a93c8873b6fb7f04b7",
     "wof:hierarchy":[
         {
@@ -360,7 +363,7 @@
         }
     ],
     "wof:id":421202663,
-    "wof:lastmodified":1566615443,
+    "wof:lastmodified":1582347043,
     "wof:name":"Cotonou",
     "wof:parent_id":85668811,
     "wof:placetype":"county",

--- a/data/856/322/47/85632247.geojson
+++ b/data/856/322/47/85632247.geojson
@@ -920,7 +920,6 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -995,7 +994,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1582347038,
+    "wof:lastmodified":1583226643,
     "wof:name":"Benin",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/47/85632247.geojson
+++ b/data/856/322/47/85632247.geojson
@@ -920,6 +920,7 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -976,6 +977,10 @@
     },
     "wof:country":"BJ",
     "wof:country_alpha3":"BEN",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"197871b96b90ad7a50de457e41bcdd2e",
     "wof:hierarchy":[
         {
@@ -990,7 +995,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566615246,
+    "wof:lastmodified":1582347038,
     "wof:name":"Benin",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/432/285/890432285.geojson
+++ b/data/890/432/285/890432285.geojson
@@ -289,6 +289,9 @@
     },
     "wof:country":"BJ",
     "wof:created":1469051935,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f4f582e427a91675a2d6b8079afec6e6",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         }
     ],
     "wof:id":890432285,
-    "wof:lastmodified":1566615447,
+    "wof:lastmodified":1582347043,
     "wof:name":"Djougou",
     "wof:parent_id":1108758889,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.