### PR TITLE
Name updates

### DIFF
--- a/data/131/057/691/1/1310576911.geojson
+++ b/data/131/057/691/1/1310576911.geojson
@@ -38,14 +38,14 @@
         "Sagon"
     ],
     "name:urd_x_preferred":[
-        "\u0633\u06af\u0648\u06ba "
+        "\u0633\u06af\u0648\u06ba"
     ],
     "src:geom":"geonames",
     "wof:belongsto":[
         102191573,
         85632247,
-        85668819,
-        1108758935
+        1108758935,
+        85668819
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1310576911,
-    "wof:lastmodified":1566615413,
+    "wof:lastmodified":1587163120,
     "wof:name":"Sagon",
     "wof:parent_id":1108758935,
     "wof:placetype":"locality",

--- a/data/856/322/47/85632247.geojson
+++ b/data/856/322/47/85632247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.500996,
-    "geom:area_square_m":115776415177.245544,
+    "geom:area_square_m":115776415652.353821,
     "geom:bbox":"0.776667,6.230061,3.843343,12.408552",
     "geom:latitude":9.652995,
     "geom:longitude":2.338755,
@@ -57,6 +57,9 @@
     "name:arg_x_preferred":[
         "Ben\u00edn"
     ],
+    "name:ary_x_preferred":[
+        "\u0628\u064a\u0646\u064a\u0646"
+    ],
     "name:arz_x_preferred":[
         "\u0628\u064a\u0646\u064a\u0646"
     ],
@@ -79,6 +82,9 @@
         "Ben\u025bn"
     ],
     "name:bam_x_variant":[
+        "Benin"
+    ],
+    "name:ban_x_preferred":[
         "Benin"
     ],
     "name:bar_x_preferred":[
@@ -165,6 +171,9 @@
     "name:dan_x_preferred":[
         "Benin"
     ],
+    "name:deu_ch_x_preferred":[
+        "Benin"
+    ],
     "name:deu_x_preferred":[
         "Benin"
     ],
@@ -188,6 +197,12 @@
     ],
     "name:ell_x_variant":[
         "\u039c\u03c0\u03ad\u03bd\u03b9\u03bd"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Benin"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Benin"
     ],
     "name:eng_x_preferred":[
         "Benin"
@@ -257,6 +272,9 @@
     ],
     "name:gag_x_preferred":[
         "Benin"
+    ],
+    "name:gcr_x_preferred":[
+        "B\u00e9nen"
     ],
     "name:ger_x_variant":[
         "Republik Benin"
@@ -505,6 +523,9 @@
     "name:mon_x_preferred":[
         "\u0411\u0435\u043d\u0438\u043d"
     ],
+    "name:mri_x_preferred":[
+        "P\u0113nina"
+    ],
     "name:mrj_x_preferred":[
         "\u0411\u0435\u043d\u0438\u043d"
     ],
@@ -607,6 +628,9 @@
     "name:pol_x_preferred":[
         "Benin"
     ],
+    "name:por_br_x_preferred":[
+        "Benin"
+    ],
     "name:por_x_preferred":[
         "Benim"
     ],
@@ -667,6 +691,9 @@
     "name:sme_x_preferred":[
         "Benin"
     ],
+    "name:smo_x_preferred":[
+        "Benin"
+    ],
     "name:sna_x_preferred":[
         "Benin"
     ],
@@ -697,6 +724,12 @@
     "name:srd_x_preferred":[
         "Benin"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0411\u0435\u043d\u0438\u043d"
+    ],
+    "name:srp_el_x_preferred":[
+        "Benin"
+    ],
     "name:srp_x_preferred":[
         "\u0411\u0435\u043d\u0438\u043d"
     ],
@@ -720,6 +753,9 @@
     ],
     "name:szl_x_preferred":[
         "By\u0144in"
+    ],
+    "name:szy_x_preferred":[
+        "Benin"
     ],
     "name:tam_x_preferred":[
         "\u0baa\u0bc6\u0ba9\u0bbf\u0ba9\u0bcd"
@@ -995,7 +1031,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1583797280,
+    "wof:lastmodified":1587428029,
     "wof:name":"Benin",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.