### PR TITLE
bj concordances, placetype local, and more

### DIFF
--- a/data/110/875/883/3/1108758833.geojson
+++ b/data/110/875/883/3/1108758833.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"BJ.AK.MA",
         "wd:id":"Q3300020"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322678,
     "wof:geomhash":"f32c83b8b475929a3e9da0155a918eaf",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108758833,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Materi",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/110/875/883/5/1108758835.geojson
+++ b/data/110/875/883/5/1108758835.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"BJ.BO.KL",
         "wd:id":"Q3192088"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322680,
     "wof:geomhash":"3ab11fb13d25268d124040d1439b0813",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108758835,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Kalale",
     "wof:parent_id":85668803,
     "wof:placetype":"county",

--- a/data/110/875/883/7/1108758837.geojson
+++ b/data/110/875/883/7/1108758837.geojson
@@ -131,6 +131,7 @@
         "hasc:id":"BJ.BO.TC",
         "wd:id":"Q1364580"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322681,
     "wof:geomhash":"f5e8583417597feb14eaae44c0555e15",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108758837,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Tchaourou",
     "wof:parent_id":85668803,
     "wof:placetype":"county",

--- a/data/110/875/883/9/1108758839.geojson
+++ b/data/110/875/883/9/1108758839.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"BJ.CL.BA",
         "wd:id":"Q1133694"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322682,
     "wof:geomhash":"206f7c395a463a980ecab55122d217b2",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108758839,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Bante",
     "wof:parent_id":85668807,
     "wof:placetype":"county",

--- a/data/110/875/884/1/1108758841.geojson
+++ b/data/110/875/884/1/1108758841.geojson
@@ -158,6 +158,7 @@
         "hasc:id":"BJ.CL.SL",
         "wd:id":"Q544623"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322683,
     "wof:geomhash":"d4fb663cd7528092801c05c67c1c74c3",
@@ -170,7 +171,7 @@
         }
     ],
     "wof:id":1108758841,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Savalou",
     "wof:parent_id":85668807,
     "wof:placetype":"county",

--- a/data/110/875/884/5/1108758845.geojson
+++ b/data/110/875/884/5/1108758845.geojson
@@ -134,6 +134,7 @@
         "hasc:id":"BJ.CF.AP",
         "wd:id":"Q2336677"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322684,
     "wof:geomhash":"d2ace6091c49c99c8ce59857e34ee317",
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108758845,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Aplahoue",
     "wof:parent_id":85668815,
     "wof:placetype":"county",

--- a/data/110/875/884/7/1108758847.geojson
+++ b/data/110/875/884/7/1108758847.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"BJ.DO.BA",
         "wd:id":"Q1893077"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322685,
     "wof:geomhash":"5d33b3174773c6fdf029a279cae92be4",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108758847,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Bassila",
     "wof:parent_id":85668827,
     "wof:placetype":"county",

--- a/data/110/875/884/9/1108758849.geojson
+++ b/data/110/875/884/9/1108758849.geojson
@@ -182,6 +182,7 @@
         "hasc:id":"BJ.MO.LO",
         "wd:id":"Q219058"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322687,
     "wof:geomhash":"eb5573d6a84550f028cf7ad547f4cc10",
@@ -194,7 +195,7 @@
         }
     ],
     "wof:id":1108758849,
-    "wof:lastmodified":1694492936,
+    "wof:lastmodified":1695886776,
     "wof:name":"Lokossa",
     "wof:parent_id":85668823,
     "wof:placetype":"county",

--- a/data/110/875/885/1/1108758851.geojson
+++ b/data/110/875/885/1/1108758851.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"BJ.PL.IF",
         "wd:id":"Q1134264"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322688,
     "wof:geomhash":"82fa71193d3573a1bad18f028bc3f3ec",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108758851,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Ifangni",
     "wof:parent_id":85668821,
     "wof:placetype":"county",

--- a/data/110/875/885/3/1108758853.geojson
+++ b/data/110/875/885/3/1108758853.geojson
@@ -131,6 +131,7 @@
         "hasc:id":"BJ.PL.KE",
         "wd:id":"Q2474638"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322690,
     "wof:geomhash":"a39f2bc4bf64e3c1b6365a0e0bbaa137",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108758853,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Ketou",
     "wof:parent_id":85668821,
     "wof:placetype":"county",

--- a/data/110/875/885/5/1108758855.geojson
+++ b/data/110/875/885/5/1108758855.geojson
@@ -131,6 +131,7 @@
         "hasc:id":"BJ.PL.PB",
         "wd:id":"Q269353"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322691,
     "wof:geomhash":"45987828a3e126187dc6943cfcfd89ee",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108758855,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Pobe",
     "wof:parent_id":85668821,
     "wof:placetype":"county",

--- a/data/110/875/885/7/1108758857.geojson
+++ b/data/110/875/885/7/1108758857.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.DO.OU",
         "wd:id":"Q1125581"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322692,
     "wof:geomhash":"69f6b385a36f343fd4fd20946c882666",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758857,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Ouake",
     "wof:parent_id":85668827,
     "wof:placetype":"county",

--- a/data/110/875/885/9/1108758859.geojson
+++ b/data/110/875/885/9/1108758859.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"BJ.AK.BO",
         "wd:id":"Q2269235"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322694,
     "wof:geomhash":"9a6a2153f0728e7a518417401c211e0d",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108758859,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Boukombe",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/110/875/886/3/1108758863.geojson
+++ b/data/110/875/886/3/1108758863.geojson
@@ -119,6 +119,7 @@
         "hasc:id":"BJ.AK.KO",
         "wd:id":"Q2527479"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322695,
     "wof:geomhash":"bfff2da55cda8cc0798c4dad6ae53ce6",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108758863,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Kouande",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/110/875/886/5/1108758865.geojson
+++ b/data/110/875/886/5/1108758865.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"BJ.AL.GO",
         "wd:id":"Q583110"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322696,
     "wof:geomhash":"faf620692836eecddd50a41c38eb6817",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108758865,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Gogounou",
     "wof:parent_id":85668805,
     "wof:placetype":"county",

--- a/data/110/875/886/7/1108758867.geojson
+++ b/data/110/875/886/7/1108758867.geojson
@@ -113,6 +113,7 @@
         "hasc:id":"BJ.AK.PE",
         "wd:id":"Q371196"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322697,
     "wof:geomhash":"54a90b450f6bda78ff4c74c67ad21b42",
@@ -125,7 +126,7 @@
         }
     ],
     "wof:id":1108758867,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Pehunco",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/110/875/886/9/1108758869.geojson
+++ b/data/110/875/886/9/1108758869.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"BJ.AK.CB",
         "wd:id":"Q545022"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322698,
     "wof:geomhash":"1ed169fef3a3887832bbee0387a1133c",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108758869,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Kobli",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/110/875/887/1/1108758871.geojson
+++ b/data/110/875/887/1/1108758871.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"BJ.AK.TO",
         "wd:id":"Q3532838"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322700,
     "wof:geomhash":"d63288cffecf3af052d68061b36b9bd9",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108758871,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886874,
     "wof:name":"Toucountouna",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/110/875/887/3/1108758873.geojson
+++ b/data/110/875/887/3/1108758873.geojson
@@ -98,6 +98,7 @@
         "hasc:id":"BJ.AQ.TB",
         "wd:id":"Q1134963"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322703,
     "wof:geomhash":"ae41bef084fbd8d509fa0a547edc8c94",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108758873,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Tori-Bossito",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/110/875/887/5/1108758875.geojson
+++ b/data/110/875/887/5/1108758875.geojson
@@ -92,6 +92,7 @@
         "hasc:id":"BJ.AQ.ZE",
         "wd:id":"Q2256918"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322704,
     "wof:geomhash":"8dacbd4e7922d5e401ec13a474b930b8",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108758875,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Ze",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/110/875/887/7/1108758877.geojson
+++ b/data/110/875/887/7/1108758877.geojson
@@ -125,6 +125,7 @@
         "hasc:id":"BJ.BO.ND",
         "wd:id":"Q1115202"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322705,
     "wof:geomhash":"1ab6c57864e70c600606620efe015165",
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108758877,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"N'dali",
     "wof:parent_id":85668803,
     "wof:placetype":"county",

--- a/data/110/875/888/1/1108758881.geojson
+++ b/data/110/875/888/1/1108758881.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.CF.DJ",
         "wd:id":"Q3032740"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322707,
     "wof:geomhash":"7453662b98885936867a87b98acb2dff",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758881,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Djakotomey",
     "wof:parent_id":85668815,
     "wof:placetype":"county",

--- a/data/110/875/888/3/1108758883.geojson
+++ b/data/110/875/888/3/1108758883.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"BJ.CF.KL",
         "wd:id":"Q3197910"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322708,
     "wof:geomhash":"c9567773651b87c16eaa7138d2bc9dff",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108758883,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Klouekanme",
     "wof:parent_id":85668815,
     "wof:placetype":"county",

--- a/data/110/875/888/5/1108758885.geojson
+++ b/data/110/875/888/5/1108758885.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"BJ.CF.LA",
         "wd:id":"Q2360019"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322709,
     "wof:geomhash":"921b87029cca53ab6a2dd8d58f7edf88",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108758885,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886875,
     "wof:name":"Lalo",
     "wof:parent_id":85668815,
     "wof:placetype":"county",

--- a/data/110/875/888/7/1108758887.geojson
+++ b/data/110/875/888/7/1108758887.geojson
@@ -140,6 +140,7 @@
         "hasc:id":"BJ.CF.DO",
         "wd:id":"Q2566827"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322711,
     "wof:geomhash":"48540782b96e95b6f42af495df92fd18",
@@ -152,7 +153,7 @@
         }
     ],
     "wof:id":1108758887,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886875,
     "wof:name":"Dogbo",
     "wof:parent_id":85668815,
     "wof:placetype":"county",

--- a/data/110/875/888/9/1108758889.geojson
+++ b/data/110/875/888/9/1108758889.geojson
@@ -224,6 +224,7 @@
         "hasc:id":"BJ.DO.DJ",
         "wd:id":"Q868198"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322712,
     "wof:geomhash":"579f8021c4ccb310927339143a5f9a62",
@@ -236,7 +237,7 @@
         }
     ],
     "wof:id":1108758889,
-    "wof:lastmodified":1694492936,
+    "wof:lastmodified":1695886776,
     "wof:name":"Djougou",
     "wof:parent_id":85668827,
     "wof:placetype":"county",

--- a/data/110/875/889/1/1108758891.geojson
+++ b/data/110/875/889/1/1108758891.geojson
@@ -95,6 +95,7 @@
         "hasc:id":"BJ.AQ.SA",
         "wd:id":"Q1118769"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322713,
     "wof:geomhash":"e2d8aa2e6bb1842293b271568c0f3dbc",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108758891,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886874,
     "wof:name":"So-Ava",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/110/875/889/3/1108758893.geojson
+++ b/data/110/875/889/3/1108758893.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.MO.BO",
         "wd:id":"Q2910571"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322715,
     "wof:geomhash":"e9992ce668e3cfdcb04f2d15697a7758",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758893,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886874,
     "wof:name":"Bopa",
     "wof:parent_id":85668823,
     "wof:placetype":"county",

--- a/data/110/875/889/5/1108758895.geojson
+++ b/data/110/875/889/5/1108758895.geojson
@@ -125,6 +125,7 @@
         "hasc:id":"BJ.MO.CO",
         "wd:id":"Q2991511"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322716,
     "wof:geomhash":"23cc77ca68327dbc324a8850f18fca99",
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108758895,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886875,
     "wof:name":"Come",
     "wof:parent_id":85668823,
     "wof:placetype":"county",

--- a/data/110/875/889/9/1108758899.geojson
+++ b/data/110/875/889/9/1108758899.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.MO.HO",
         "wd:id":"Q3141428"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322717,
     "wof:geomhash":"42719acfeed7adeefcd048aa1e364eea",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758899,
-    "wof:lastmodified":1694492376,
+    "wof:lastmodified":1695886874,
     "wof:name":"Houeyogbe",
     "wof:parent_id":85668823,
     "wof:placetype":"county",

--- a/data/110/875/890/1/1108758901.geojson
+++ b/data/110/875/890/1/1108758901.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.OU.AH",
         "wd:id":"Q1134538"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322718,
     "wof:geomhash":"7d12cb549a6b86dc78691bc02f2a2714",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758901,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Adjohoun",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/110/875/890/3/1108758903.geojson
+++ b/data/110/875/890/3/1108758903.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"BJ.OU.AM",
         "wd:id":"Q2274435"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322719,
     "wof:geomhash":"1c7dbd52c7b2559f94f72fc706e78e6f",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108758903,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Akpo-Misserete",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/110/875/890/5/1108758905.geojson
+++ b/data/110/875/890/5/1108758905.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.OU.AG",
         "wd:id":"Q605293"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322720,
     "wof:geomhash":"b93f8988c733591208b6ccd1d8d12b15",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758905,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Aguegues",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/110/875/890/7/1108758907.geojson
+++ b/data/110/875/890/7/1108758907.geojson
@@ -95,6 +95,7 @@
         "hasc:id":"BJ.OU.BO",
         "wd:id":"Q1134995"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322722,
     "wof:geomhash":"6b90996df8bf31162ce7f88d3fadc196",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108758907,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Bonou",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/110/875/890/9/1108758909.geojson
+++ b/data/110/875/890/9/1108758909.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.OU.DA",
         "wd:id":"Q2684866"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322723,
     "wof:geomhash":"34d8ca2912e1058f09f934a8bcdda8c3",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758909,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Dangbo",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/110/875/891/1/1108758911.geojson
+++ b/data/110/875/891/1/1108758911.geojson
@@ -104,6 +104,7 @@
         "hasc:id":"BJ.OU.AV",
         "wd:id":"Q2375902"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322724,
     "wof:geomhash":"a7da3909ba0cfcfaa199f8d41e0b1071",
@@ -116,7 +117,7 @@
         }
     ],
     "wof:id":1108758911,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Avrankou",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/110/875/891/3/1108758913.geojson
+++ b/data/110/875/891/3/1108758913.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.OU.AA",
         "wd:id":"Q2476120"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322727,
     "wof:geomhash":"c9d3b9695da77edefff2d54eff1206f7",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758913,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Adjarra",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/110/875/891/7/1108758917.geojson
+++ b/data/110/875/891/7/1108758917.geojson
@@ -98,6 +98,7 @@
         "hasc:id":"BJ.OU.SK",
         "wd:id":"Q2100355"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322728,
     "wof:geomhash":"d0fcb5f336268c8e460e8312e1059fb3",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108758917,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Seme-Kpodji",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/110/875/891/9/1108758919.geojson
+++ b/data/110/875/891/9/1108758919.geojson
@@ -125,6 +125,7 @@
         "hasc:id":"BJ.PL.SA",
         "wd:id":"Q959156"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322729,
     "wof:geomhash":"cdaded87c9e8feaee518c841f5ac8a67",
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1108758919,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Sakete",
     "wof:parent_id":85668821,
     "wof:placetype":"county",

--- a/data/110/875/892/1/1108758921.geojson
+++ b/data/110/875/892/1/1108758921.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.ZO.AG",
         "wd:id":"Q527734"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322730,
     "wof:geomhash":"2cab0859752ece2a1e1b0464f7130f93",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758921,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886876,
     "wof:name":"Agbangnizoun",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/892/3/1108758923.geojson
+++ b/data/110/875/892/3/1108758923.geojson
@@ -134,6 +134,7 @@
         "hasc:id":"BJ.ZO.BO",
         "wd:id":"Q2356092"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322731,
     "wof:geomhash":"9680df423d93a070dae79cfe7aac8c66",
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108758923,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886876,
     "wof:name":"Bohicon",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/892/5/1108758925.geojson
+++ b/data/110/875/892/5/1108758925.geojson
@@ -299,6 +299,7 @@
         "hasc:id":"BJ.CL.DZ",
         "wd:id":"Q2609335"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322732,
     "wof:geomhash":"b331c6d1ba963c24b6a9e961d1120a50",
@@ -311,7 +312,7 @@
         }
     ],
     "wof:id":1108758925,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886876,
     "wof:name":"Dassa-Zoume",
     "wof:parent_id":85668807,
     "wof:placetype":"county",

--- a/data/110/875/892/7/1108758927.geojson
+++ b/data/110/875/892/7/1108758927.geojson
@@ -98,6 +98,7 @@
         "hasc:id":"BJ.ZO.DJ",
         "wd:id":"Q1133856"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322734,
     "wof:geomhash":"05e0c4aa4f0df38a709cdccdc825112a",
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108758927,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886876,
     "wof:name":"Djidja",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/892/9/1108758929.geojson
+++ b/data/110/875/892/9/1108758929.geojson
@@ -128,7 +128,7 @@
         }
     ],
     "wof:id":1108758929,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886875,
     "wof:name":"Cove",
     "wof:parent_id":85668807,
     "wof:placetype":"county",

--- a/data/110/875/893/1/1108758931.geojson
+++ b/data/110/875/893/1/1108758931.geojson
@@ -107,6 +107,7 @@
         "hasc:id":"BJ.PL.AO",
         "wd:id":"Q1133867"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322738,
     "wof:geomhash":"67463f2de3d21622b788ba6f82ded899",
@@ -119,7 +120,7 @@
         }
     ],
     "wof:id":1108758931,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Adja-Ouere",
     "wof:parent_id":85668821,
     "wof:placetype":"county",

--- a/data/110/875/893/5/1108758935.geojson
+++ b/data/110/875/893/5/1108758935.geojson
@@ -95,6 +95,7 @@
         "hasc:id":"BJ.ZO.ON",
         "wd:id":"Q1134277"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322739,
     "wof:geomhash":"514612a049353188a7f79f25f856a1ca",
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108758935,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Ouinhi",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/893/7/1108758937.geojson
+++ b/data/110/875/893/7/1108758937.geojson
@@ -88,6 +88,7 @@
     "wof:concordances":{
         "hasc:id":"BJ.ZO.ZK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322741,
     "wof:geomhash":"27aaab6f6675050d2286aa6ce6da25be",
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108758937,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886877,
     "wof:name":"Zagnanado",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/893/9/1108758939.geojson
+++ b/data/110/875/893/9/1108758939.geojson
@@ -92,6 +92,7 @@
         "hasc:id":"BJ.ZO.ZB",
         "wd:id":"Q2050232"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322743,
     "wof:geomhash":"bce7fa6d9541e2574871316439e2ac3b",
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108758939,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Zogbodomey",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/894/1/1108758941.geojson
+++ b/data/110/875/894/1/1108758941.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"BJ.ZO.CO",
         "wd:id":"Q2464735"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322744,
     "wof:geomhash":"f31fe60cace5d8c310f44f7292121328",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108758941,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Cove",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/894/3/1108758943.geojson
+++ b/data/110/875/894/3/1108758943.geojson
@@ -134,6 +134,7 @@
         "hasc:id":"BJ.BO.NI",
         "wd:id":"Q2378608"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322747,
     "wof:geomhash":"dd7828f405ef17c03fddfe778a2cc3d6",
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1108758943,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Nikki",
     "wof:parent_id":85668803,
     "wof:placetype":"county",

--- a/data/110/875/894/5/1108758945.geojson
+++ b/data/110/875/894/5/1108758945.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.CL.GL",
         "wd:id":"Q2449849"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322748,
     "wof:geomhash":"b75ab43f08c6c3278b383e423c2eff35",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758945,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Glazoue",
     "wof:parent_id":85668807,
     "wof:placetype":"county",

--- a/data/110/875/894/7/1108758947.geojson
+++ b/data/110/875/894/7/1108758947.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.CF.TO",
         "wd:id":"Q2647400"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322749,
     "wof:geomhash":"83dabd1c8d09723c28d00f3caee9a89a",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758947,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Toviklin",
     "wof:parent_id":85668815,
     "wof:placetype":"county",

--- a/data/110/875/894/9/1108758949.geojson
+++ b/data/110/875/894/9/1108758949.geojson
@@ -278,6 +278,7 @@
         "hasc:id":"BJ.ZO.AB",
         "wd:id":"Q189685"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322750,
     "wof:geomhash":"a84c8b57047bb48f6456fbe9d8855351",
@@ -290,7 +291,7 @@
         }
     ],
     "wof:id":1108758949,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Abomey",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/895/3/1108758953.geojson
+++ b/data/110/875/895/3/1108758953.geojson
@@ -88,6 +88,7 @@
     "wof:concordances":{
         "hasc:id":"BJ.ZO.ZN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322751,
     "wof:geomhash":"158fe15a367f9ebd26fb9648e8abf2b3",
@@ -100,7 +101,7 @@
         }
     ],
     "wof:id":1108758953,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886876,
     "wof:name":"Za-Kpota",
     "wof:parent_id":85668819,
     "wof:placetype":"county",

--- a/data/110/875/895/5/1108758955.geojson
+++ b/data/110/875/895/5/1108758955.geojson
@@ -122,6 +122,7 @@
         "hasc:id":"BJ.AL.KR",
         "wd:id":"Q1860831"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322753,
     "wof:geomhash":"7db5fe08fcde64f999a26a9d620d7c0d",
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108758955,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886876,
     "wof:name":"Karimama",
     "wof:parent_id":85668805,
     "wof:placetype":"county",

--- a/data/110/875/895/7/1108758957.geojson
+++ b/data/110/875/895/7/1108758957.geojson
@@ -146,6 +146,7 @@
         "hasc:id":"BJ.AL.MA",
         "wd:id":"Q2337446"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322754,
     "wof:geomhash":"f634233e91c10ad3e728aaba5e09db7b",
@@ -158,7 +159,7 @@
         }
     ],
     "wof:id":1108758957,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886877,
     "wof:name":"Malanville",
     "wof:parent_id":85668805,
     "wof:placetype":"county",

--- a/data/110/875/895/9/1108758959.geojson
+++ b/data/110/875/895/9/1108758959.geojson
@@ -131,6 +131,7 @@
         "hasc:id":"BJ.AL.SE",
         "wd:id":"Q2202003"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322755,
     "wof:geomhash":"f00022773bfda15a08601f6c4a987898",
@@ -143,7 +144,7 @@
         }
     ],
     "wof:id":1108758959,
-    "wof:lastmodified":1694492377,
+    "wof:lastmodified":1695886876,
     "wof:name":"Segbana",
     "wof:parent_id":85668805,
     "wof:placetype":"county",

--- a/data/110/875/896/1/1108758961.geojson
+++ b/data/110/875/896/1/1108758961.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.CL.OS",
         "wd:id":"Q1133661"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322756,
     "wof:geomhash":"1b8876fb3fc8a0b3487c2b7a3aca7db0",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758961,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Ouesse",
     "wof:parent_id":85668807,
     "wof:placetype":"county",

--- a/data/110/875/896/3/1108758963.geojson
+++ b/data/110/875/896/3/1108758963.geojson
@@ -153,6 +153,7 @@
         "hasc:id":"BJ.CL.SE",
         "wd:id":"Q2609291"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322757,
     "wof:geomhash":"e107b13de69667a9e8e30727888e3206",
@@ -165,7 +166,7 @@
         }
     ],
     "wof:id":1108758963,
-    "wof:lastmodified":1694492936,
+    "wof:lastmodified":1695886776,
     "wof:name":"Save",
     "wof:parent_id":85668807,
     "wof:placetype":"county",

--- a/data/110/875/896/5/1108758965.geojson
+++ b/data/110/875/896/5/1108758965.geojson
@@ -119,6 +119,7 @@
         "hasc:id":"BJ.MO.AT",
         "wd:id":"Q2682057"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322758,
     "wof:geomhash":"7d4e3c28d2d1a8979a2fd8eda354c418",
@@ -131,7 +132,7 @@
         }
     ],
     "wof:id":1108758965,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Athieme",
     "wof:parent_id":85668823,
     "wof:placetype":"county",

--- a/data/110/875/896/7/1108758967.geojson
+++ b/data/110/875/896/7/1108758967.geojson
@@ -128,6 +128,7 @@
         "hasc:id":"BJ.AL.BA",
         "wd:id":"Q2200458"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322760,
     "wof:geomhash":"63b94f8e1f480639225c3c4a5cbf323a",
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108758967,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886878,
     "wof:name":"Banikoara",
     "wof:parent_id":85668805,
     "wof:placetype":"county",

--- a/data/110/875/897/1/1108758971.geojson
+++ b/data/110/875/897/1/1108758971.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"BJ.AK.KE",
         "wd:id":"Q2269207"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322761,
     "wof:geomhash":"53dbb5fd31d5baa5358f22732f6b5bb8",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108758971,
-    "wof:lastmodified":1694492379,
+    "wof:lastmodified":1695886880,
     "wof:name":"Kerou",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/110/875/897/3/1108758973.geojson
+++ b/data/110/875/897/3/1108758973.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.BO.SI",
         "wd:id":"Q1857012"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322762,
     "wof:geomhash":"357d0e63fb482398b619692f8703ca47",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758973,
-    "wof:lastmodified":1694492379,
+    "wof:lastmodified":1695886880,
     "wof:name":"Sinende",
     "wof:parent_id":85668803,
     "wof:placetype":"county",

--- a/data/110/875/897/5/1108758975.geojson
+++ b/data/110/875/897/5/1108758975.geojson
@@ -194,6 +194,7 @@
         "hasc:id":"BJ.AL.KN",
         "wd:id":"Q845666"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322764,
     "wof:geomhash":"4c8716a714140c13491f80d54b3dbf83",
@@ -206,7 +207,7 @@
         }
     ],
     "wof:id":1108758975,
-    "wof:lastmodified":1694492936,
+    "wof:lastmodified":1695886776,
     "wof:name":"Kandi",
     "wof:parent_id":85668805,
     "wof:placetype":"county",

--- a/data/110/875/897/7/1108758977.geojson
+++ b/data/110/875/897/7/1108758977.geojson
@@ -116,6 +116,7 @@
         "hasc:id":"BJ.AQ.TF",
         "wd:id":"Q2095710"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322765,
     "wof:geomhash":"31d8f5e8c0dd98a4aff654c903c42c59",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108758977,
-    "wof:lastmodified":1694492379,
+    "wof:lastmodified":1695886880,
     "wof:name":"Toffo",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/110/875/897/9/1108758979.geojson
+++ b/data/110/875/897/9/1108758979.geojson
@@ -128,6 +128,7 @@
         "hasc:id":"BJ.BO.BE",
         "wd:id":"Q2271297"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322766,
     "wof:geomhash":"2cb6e892f4bb56946de323a3e9113c2c",
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":1108758979,
-    "wof:lastmodified":1694492379,
+    "wof:lastmodified":1695886880,
     "wof:name":"Bembereke",
     "wof:parent_id":85668803,
     "wof:placetype":"county",

--- a/data/110/875/898/1/1108758981.geojson
+++ b/data/110/875/898/1/1108758981.geojson
@@ -101,6 +101,7 @@
         "hasc:id":"BJ.BO.PE",
         "wd:id":"Q2716795"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322767,
     "wof:geomhash":"fbe8f1e620bd919e4d52de66d823e5f7",
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108758981,
-    "wof:lastmodified":1694492378,
+    "wof:lastmodified":1695886879,
     "wof:name":"Perere",
     "wof:parent_id":85668803,
     "wof:placetype":"county",

--- a/data/110/875/898/3/1108758983.geojson
+++ b/data/110/875/898/3/1108758983.geojson
@@ -239,6 +239,7 @@
         "hasc:id":"BJ.BO.PA",
         "wd:id":"Q688324"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322768,
     "wof:geomhash":"84e1e2c8ee78804a152bb458cb7e007f",
@@ -251,7 +252,7 @@
         }
     ],
     "wof:id":1108758983,
-    "wof:lastmodified":1694492379,
+    "wof:lastmodified":1695886879,
     "wof:name":"Parakou",
     "wof:parent_id":85668803,
     "wof:placetype":"county",

--- a/data/110/875/898/5/1108758985.geojson
+++ b/data/110/875/898/5/1108758985.geojson
@@ -110,6 +110,7 @@
         "hasc:id":"BJ.DO.CP",
         "wd:id":"Q986059"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1481322769,
     "wof:geomhash":"39239a678c66ae59c3e147212866362d",
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108758985,
-    "wof:lastmodified":1694492379,
+    "wof:lastmodified":1695886879,
     "wof:name":"Copargo",
     "wof:parent_id":85668827,
     "wof:placetype":"county",

--- a/data/421/169/223/421169223.geojson
+++ b/data/421/169/223/421169223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003984,
-    "geom:area_square_m":48950100.989528,
+    "geom:area_square_m":48950100.989527,
     "geom:bbox":"2.581441,6.44465,2.663749,6.526642",
     "geom:latitude":6.482035,
     "geom:longitude":2.620369,
@@ -549,6 +549,7 @@
         "qs_pg:id":1200744,
         "wd:id":"Q3799"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421168997
     ],
@@ -557,7 +558,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf2609d0b70995900f36cc9101fbb455",
+    "wof:geomhash":"a504801a8b2da9484b0caa8434473e7a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -567,7 +568,7 @@
         }
     ],
     "wof:id":421169223,
-    "wof:lastmodified":1690858516,
+    "wof:lastmodified":1695886403,
     "wof:name":"Porto-Novo",
     "wof:parent_id":85668817,
     "wof:placetype":"county",

--- a/data/421/169/231/421169231.geojson
+++ b/data/421/169/231/421169231.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112004,
-    "geom:area_square_m":1362885868.519548,
+    "geom:area_square_m":1362886080.039776,
     "geom:bbox":"1.197925,10.015015,1.628203,10.440506",
     "geom:latitude":10.241899,
     "geom:longitude":1.4069,
@@ -250,12 +250,13 @@
         "qs_pg:id":1200756,
         "wd:id":"Q994125"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1459008800,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"97f54f4eec55ad3a4d430a4a577c5292",
+    "wof:geomhash":"6e439850c9475fb963f2fb42a99269cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -265,7 +266,7 @@
         }
     ],
     "wof:id":421169231,
-    "wof:lastmodified":1690858516,
+    "wof:lastmodified":1695886776,
     "wof:name":"Natitingou",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/421/172/113/421172113.geojson
+++ b/data/421/172/113/421172113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.45989,
-    "geom:area_square_m":5581476141.473667,
+    "geom:area_square_m":5581475645.652154,
     "geom:bbox":"1.042219,10.413761,1.942465,11.480865",
     "geom:latitude":11.032828,
     "geom:longitude":1.438569,
@@ -135,12 +135,13 @@
         "qs_pg:id":1296978,
         "wd:id":"Q2269248"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1459008920,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"65f4fabe72f90be99fa2185f34e344ac",
+    "wof:geomhash":"425f35d4de976b7cbf9009e4bcf3802c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":421172113,
-    "wof:lastmodified":1690858518,
+    "wof:lastmodified":1695886787,
     "wof:name":"Tanguieta",
     "wof:parent_id":85668825,
     "wof:placetype":"county",

--- a/data/421/174/729/421174729.geojson
+++ b/data/421/174/729/421174729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025808,
-    "geom:area_square_m":317137923.47151,
+    "geom:area_square_m":317137858.248827,
     "geom:bbox":"1.96047,6.301323,2.271416,6.48824",
     "geom:latitude":6.380993,
     "geom:longitude":2.125741,
@@ -232,12 +232,13 @@
         "qs_pg:id":896688,
         "wd:id":"Q850031"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1459009042,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c7df51150091a6399ee735734a29b61",
+    "wof:geomhash":"63a9857addb7a0f974e29613beb3ea59",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -247,7 +248,7 @@
         }
     ],
     "wof:id":421174729,
-    "wof:lastmodified":1690858517,
+    "wof:lastmodified":1695886776,
     "wof:name":"Ouidah",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/421/177/249/421177249.geojson
+++ b/data/421/177/249/421177249.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.022284,
-    "geom:area_square_m":273860853.052166,
+    "geom:area_square_m":273860663.121487,
     "geom:bbox":"1.630718,6.230061,1.977221,6.477931",
     "geom:latitude":6.345138,
     "geom:longitude":1.8312,
@@ -168,12 +168,13 @@
         "qs_pg:id":1136724,
         "wd:id":"Q1542478"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1459009137,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b263d2355077767310741bc157fcc2c9",
+    "wof:geomhash":"45411c920e36064cf1a78577f38d207e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":421177249,
-    "wof:lastmodified":1690858521,
+    "wof:lastmodified":1695886788,
     "wof:name":"Grand-Popo",
     "wof:parent_id":85668823,
     "wof:placetype":"county",

--- a/data/421/186/271/421186271.geojson
+++ b/data/421/186/271/421186271.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043096,
-    "geom:area_square_m":529463353.231466,
+    "geom:area_square_m":529463608.267293,
     "geom:bbox":"2.20911,6.340305,2.416652,6.698475",
     "geom:latitude":6.498521,
     "geom:longitude":2.321292,
@@ -166,12 +166,13 @@
         "qs_pg:id":1063140,
         "wd:id":"Q2473939"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1459009475,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6961b8e7f83ddbf0df6d8adf226ea8b1",
+    "wof:geomhash":"5279ec5ccb50f6ffcc5b048679bd9a1a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -181,7 +182,7 @@
         }
     ],
     "wof:id":421186271,
-    "wof:lastmodified":1690858518,
+    "wof:lastmodified":1695886788,
     "wof:name":"Abomey-Calavi",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/421/195/933/421195933.geojson
+++ b/data/421/195/933/421195933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023908,
-    "geom:area_square_m":293755174.918883,
+    "geom:area_square_m":293755120.822198,
     "geom:bbox":"1.941811,6.340613,2.088129,6.62317",
     "geom:latitude":6.453114,
     "geom:longitude":2.013055,
@@ -129,12 +129,13 @@
         "qs_pg:id":141167,
         "wd:id":"Q2693366"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1459009864,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1fd3b317ad2570237d356a680a280503",
+    "wof:geomhash":"d633758b9c4b3eec99ad2ee11b30fb27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":421195933,
-    "wof:lastmodified":1690858515,
+    "wof:lastmodified":1695886787,
     "wof:name":"Kpomasse",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/421/202/551/421202551.geojson
+++ b/data/421/202/551/421202551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.031691,
-    "geom:area_square_m":389202912.671764,
+    "geom:area_square_m":389203094.513072,
     "geom:bbox":"1.986668,6.580894,2.247617,6.782367",
     "geom:latitude":6.675978,
     "geom:longitude":2.118768,
@@ -160,12 +160,13 @@
         "qs_pg:id":224315,
         "wd:id":"Q960239"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"BJ",
     "wof:created":1459010122,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c575a7fc8abf82dc6906531e3819526b",
+    "wof:geomhash":"ba3ee045da98d4626b7e059c106bab90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -175,7 +176,7 @@
         }
     ],
     "wof:id":421202551,
-    "wof:lastmodified":1690858516,
+    "wof:lastmodified":1695886788,
     "wof:name":"Allada",
     "wof:parent_id":85668809,
     "wof:placetype":"county",

--- a/data/421/202/663/421202663.geojson
+++ b/data/421/202/663/421202663.geojson
@@ -387,6 +387,7 @@
         "qs_pg:id":225266,
         "wd:id":"Q43595"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         421169001
     ],
@@ -395,7 +396,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"507b549342f9584e02d078d38cf2c8fa",
+    "wof:geomhash":"b990921b556a46de7ccf45656a2ada45",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -405,7 +406,7 @@
         }
     ],
     "wof:id":421202663,
-    "wof:lastmodified":1690858517,
+    "wof:lastmodified":1695886403,
     "wof:name":"Cotonou",
     "wof:parent_id":85668811,
     "wof:placetype":"county",

--- a/data/856/322/47/85632247.geojson
+++ b/data/856/322/47/85632247.geojson
@@ -1161,6 +1161,7 @@
         "hasc:id":"BJ",
         "icao:code":"TY",
         "ioc:id":"BEN",
+        "iso:code":"BJ",
         "itu:id":"BEN",
         "loc:id":"n79110959",
         "m49:code":"204",
@@ -1175,6 +1176,7 @@
         "wk:page":"Benin",
         "wmo:id":"BJ"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
     "wof:country_alpha3":"BEN",
     "wof:geom_alt":[
@@ -1197,7 +1199,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639633,
+    "wof:lastmodified":1695881295,
     "wof:name":"Benin",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/688/03/85668803.geojson
+++ b/data/856/688/03/85668803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.11162,
-    "geom:area_square_m":25730525322.80788,
+    "geom:area_square_m":25730525726.638824,
     "geom:bbox":"1.970247,8.771218,3.837419,10.630609",
     "geom:latitude":9.775569,
     "geom:longitude":2.761061,
@@ -296,14 +296,16 @@
         "gn:id":2394992,
         "gp:id":2344826,
         "hasc:id":"BJ.BO",
+        "iso:code":"BJ-BO",
         "iso:id":"BJ-BO",
         "qs_pg:id":894846,
         "unlc:id":"BJ-BO",
         "wd:id":"Q29136",
         "wk:page":"Borgou Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"74aa7e80c47c960c7339753a42ce1b5b",
+    "wof:geomhash":"a73902799a70977b8f5e2146010e3de5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858494,
+    "wof:lastmodified":1695884882,
     "wof:name":"Borgou",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/05/85668805.geojson
+++ b/data/856/688/05/85668805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.21028,
-    "geom:area_square_m":26797401514.536457,
+    "geom:area_square_m":26797396475.402702,
     "geom:bbox":"2.015429,10.517834,3.837246,12.399244",
     "geom:latitude":11.326073,
     "geom:longitude":2.899471,
@@ -302,14 +302,16 @@
         "gn:id":2597271,
         "gp:id":55967672,
         "hasc:id":"BJ.AL",
+        "iso:code":"BJ-AL",
         "iso:id":"BJ-AL",
         "qs_pg:id":264100,
         "unlc:id":"BJ-AL",
         "wd:id":"Q29165",
         "wk:page":"Alibori Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"db55730723c2e9291e1e5069a09ac32f",
+    "wof:geomhash":"b0a59885544c072a11287524c3332ece",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858494,
+    "wof:lastmodified":1695884882,
     "wof:name":"Alibori",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/07/85668807.geojson
+++ b/data/856/688/07/85668807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.176855,
-    "geom:area_square_m":14405817439.63834,
+    "geom:area_square_m":14405818667.175879,
     "geom:bbox":"1.60107,7.426033,2.744773,8.776674",
     "geom:latitude":8.122761,
     "geom:longitude":2.194288,
@@ -296,14 +296,16 @@
         "gn:id":2597272,
         "gp:id":55967670,
         "hasc:id":"BJ.CL",
+        "iso:code":"BJ-CO",
         "iso:id":"BJ-CO",
         "qs_pg:id":1200743,
         "unlc:id":"BJ-CO",
         "wd:id":"Q29141",
         "wk:page":"Collines Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"e63901308ed0c1d9c1aca8e43577fede",
+    "wof:geomhash":"121dc06b0f8315f982222e0cbeb50fdc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858496,
+    "wof:lastmodified":1695884882,
     "wof:name":"Collines",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/09/85668809.geojson
+++ b/data/856/688/09/85668809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256572,
-    "geom:area_square_m":3151530980.976142,
+    "geom:area_square_m":3151531440.32134,
     "geom:bbox":"1.957845,6.286521,2.487425,6.92056",
     "geom:latitude":6.598127,
     "geom:longitude":2.220157,
@@ -299,14 +299,16 @@
         "gn:id":2395504,
         "gp:id":2344825,
         "hasc:id":"BJ.AQ",
+        "iso:code":"BJ-AQ",
         "iso:id":"BJ-AQ",
         "qs_pg:id":235567,
         "unlc:id":"BJ-AQ",
         "wd:id":"Q29147",
         "wk:page":"Atlantique Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"bb0fbf86625538b31b76a82c03bfb59c",
+    "wof:geomhash":"377be0de6ace081685a4a8ef43b26083",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858496,
+    "wof:lastmodified":1695884882,
     "wof:name":"Atlantique",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/11/85668811.geojson
+++ b/data/856/688/11/85668811.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00472,
-    "geom:area_square_m":58002012.749698,
+    "geom:area_square_m":58002532.478256,
     "geom:bbox":"2.359853,6.336401,2.483952,6.395837",
     "geom:latitude":6.363618,
     "geom:longitude":2.424063,
@@ -302,14 +302,16 @@
         "gn:id":2597275,
         "gp:id":55967673,
         "hasc:id":"BJ.LI",
+        "iso:code":"BJ-LI",
         "iso:id":"BJ-LI",
         "qs_pg:id":224308,
         "unlc:id":"BJ-LI",
         "wd:id":"Q29158",
         "wk:page":"Littoral Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"9a8ee3ec21b4ea6f14972c568c2c486e",
+    "wof:geomhash":"88c84da3d02731f33463cca32a5ef88c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -324,7 +326,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858494,
+    "wof:lastmodified":1695884882,
     "wof:name":"Littoral",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/15/85668815.geojson
+++ b/data/856/688/15/85668815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.22427,
-    "geom:area_square_m":2752468492.684277,
+    "geom:area_square_m":2752469131.561603,
     "geom:bbox":"1.531927,6.68998,2.093134,7.536385",
     "geom:latitude":6.998202,
     "geom:longitude":1.773873,
@@ -296,14 +296,16 @@
         "gn:id":2597273,
         "gp:id":55967668,
         "hasc:id":"BJ.CF",
+        "iso:code":"BJ-KO",
         "iso:id":"BJ-KO",
         "qs_pg:id":575163,
         "unlc:id":"BJ-KO",
         "wd:id":"Q29173",
         "wk:page":"Kouffo Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"05ddc700fbe2a40aeb225bcbec7ad983",
+    "wof:geomhash":"1fc6d5136a4d96b3fc3decce25be0a0c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858496,
+    "wof:lastmodified":1695884882,
     "wof:name":"Kouffo",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/17/85668817.geojson
+++ b/data/856/688/17/85668817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.112183,
-    "geom:area_square_m":1377882304.063904,
+    "geom:area_square_m":1377882500.075825,
     "geom:bbox":"2.384899,6.347932,2.718803,6.993553",
     "geom:latitude":6.629277,
     "geom:longitude":2.539303,
@@ -306,14 +306,16 @@
         "gn:id":2392325,
         "gp:id":2344828,
         "hasc:id":"BJ.OU",
+        "iso:code":"BJ-OU",
         "iso:id":"BJ-OU",
         "qs_pg:id":1083803,
         "unlc:id":"BJ-OU",
         "wd:id":"Q29169",
         "wk:page":"Ou\u00e9m\u00e9 Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"42d52e32e51c9c34117e7e20d966498b",
+    "wof:geomhash":"a89b4dea69864f9eafdadd0da742ec1d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -328,7 +330,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858495,
+    "wof:lastmodified":1695884326,
     "wof:name":"Ou\u00e9m\u00e9",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/19/85668819.geojson
+++ b/data/856/688/19/85668819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.41656,
-    "geom:area_square_m":5109465783.854222,
+    "geom:area_square_m":5109465174.107918,
     "geom:bbox":"1.622855,6.91193,2.560082,7.632403",
     "geom:latitude":7.265427,
     "geom:longitude":2.110191,
@@ -296,14 +296,16 @@
         "gn:id":2390719,
         "gp:id":2344829,
         "hasc:id":"BJ.ZO",
+        "iso:code":"BJ-ZO",
         "iso:id":"BJ-ZO",
         "qs_pg:id":1083804,
         "unlc:id":"BJ-ZO",
         "wd:id":"Q29172",
         "wk:page":"Zou Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"652e7496e2752b57e22609a043f3147b",
+    "wof:geomhash":"6721fd02139922e69aff5c4fc967c2ac",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -318,7 +320,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858495,
+    "wof:lastmodified":1695884326,
     "wof:name":"Zou",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/21/85668821.geojson
+++ b/data/856/688/21/85668821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.252075,
-    "geom:area_square_m":3092434383.679336,
+    "geom:area_square_m":3092433661.340816,
     "geom:bbox":"2.417765,6.504298,2.792315,7.659714",
     "geom:latitude":7.18671,
     "geom:longitude":2.625202,
@@ -293,14 +293,16 @@
         "gn:id":2597277,
         "gp:id":55967669,
         "hasc:id":"BJ.PL",
+        "iso:code":"BJ-PL",
         "iso:id":"BJ-PL",
         "qs_pg:id":894129,
         "unlc:id":"BJ-PL",
         "wd:id":"Q32108",
         "wk:page":"Plateau Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"e1f7e73205d57a98ebbed196c99a5105",
+    "wof:geomhash":"dff9ae39dcb806b75802552e94ce0030",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -315,7 +317,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858495,
+    "wof:lastmodified":1695884882,
     "wof:name":"Plateau",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/23/85668823.geojson
+++ b/data/856/688/23/85668823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.141187,
-    "geom:area_square_m":1734498080.361275,
+    "geom:area_square_m":1734498319.920103,
     "geom:bbox":"1.566033,6.213899,2.023629,6.747005",
     "geom:latitude":6.522928,
     "geom:longitude":1.827585,
@@ -299,14 +299,16 @@
         "gn:id":2392716,
         "gp:id":2344827,
         "hasc:id":"BJ.MO",
+        "iso:code":"BJ-MO",
         "iso:id":"BJ-MO",
         "qs_pg:id":1097025,
         "unlc:id":"BJ-MO",
         "wd:id":"Q29135",
         "wk:page":"Mono Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"555cdecbbbb39ee3098edac0734c26a1",
+    "wof:geomhash":"eda3b979e8d89525633f5899f42e0786",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -321,7 +323,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858496,
+    "wof:lastmodified":1695884326,
     "wof:name":"Mono",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/25/85668825.geojson
+++ b/data/856/688/25/85668825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.756027,
-    "geom:area_square_m":21336672354.932583,
+    "geom:area_square_m":21336673364.848846,
     "geom:bbox":"0.759881,9.946887,2.356167,11.473771",
     "geom:latitude":10.683899,
     "geom:longitude":1.582111,
@@ -303,14 +303,16 @@
         "gn:id":2395524,
         "gp:id":2344824,
         "hasc:id":"BJ.AK",
+        "iso:code":"BJ-AK",
         "iso:id":"BJ-AK",
         "qs_pg:id":318308,
         "unlc:id":"BJ-AK",
         "wd:id":"Q29154",
         "wk:page":"Atakora Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"1f05546efc1b22e3631b3012add38359",
+    "wof:geomhash":"f3c9c3b057551d548b9bbcd641eead58",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -325,7 +327,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858497,
+    "wof:lastmodified":1695884882,
     "wof:name":"Atakora",
     "wof:parent_id":85632247,
     "wof:placetype":"region",

--- a/data/856/688/27/85668827.geojson
+++ b/data/856/688/27/85668827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.905763,
-    "geom:area_square_m":11051273808.790834,
+    "geom:area_square_m":11051275660.831482,
     "geom:bbox":"1.323154,8.475607,2.220103,10.040447",
     "geom:latitude":9.336324,
     "geom:longitude":1.788044,
@@ -298,14 +298,16 @@
         "gn:id":2597274,
         "gp:id":55967671,
         "hasc:id":"BJ.DO",
+        "iso:code":"BJ-DO",
         "iso:id":"BJ-DO",
         "qs_pg:id":575164,
         "unlc:id":"BJ-DO",
         "wd:id":"Q29161",
         "wk:page":"Donga Department"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BJ",
-    "wof:geomhash":"50108586f2d2f5bdac3d26f23df1ee56",
+    "wof:geomhash":"c344205f8aeaf14402470bb7f224d1e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690858494,
+    "wof:lastmodified":1695884882,
     "wof:name":"Donga",
     "wof:parent_id":85632247,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.